### PR TITLE
Expand iperf version tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./bootstrap.sh ;fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure && make && sudo make install ;fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd .. ;fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export LD_LIBRARY_PATH=/usr/local/lib ;fi
       #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq ;fi
       #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y iperf3 ;fi
     # Install iperf3, python3 and activate venv for osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 language: python
+python:
+    - "2.6"
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+    - "3.5-dev"
+    - "nightly"
 matrix:
     include:
         # Use the built in venv for linux builds
         - os: linux
           sudo: required
           dist: trusty
-          python:
-              - "2.6"
-              - "2.7"
-              - "3.3"
-              - "3.4"
-              - "3.5"
-              - "3.5-dev"
-              - "nightly"
           env:
               - IPERF_VERSION="3.0.1"
               - IPERF_VERSION="3.0.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ matrix:
         - os: linux
           sudo: required
           dist: trusty
-          python: 
-            - "2.6"
-            - "2.7"
-            - "3.3"
-            - "3.4"
-            - "3.5"
-            - "3.5-dev"
-            - "nightly"
+          python:
+              - "2.6"
+              - "2.7"
+              - "3.3"
+              - "3.4"
+              - "3.5"
+              - "3.5-dev"
+              - "nightly"
           env:
               - IPERF_VERSION="3.0.1"
               - IPERF_VERSION="3.0.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,20 @@ matrix:
           sudo: required
           dist: trusty
           python: "nightly"
+          env:
+              - IPERF_VERSION="1.0.7"
+              - IPERF_VERSION="2.0.1"
 before_install:
     # Install iperf3 on linux
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq ;fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y iperf3 ;fi
+    - if [[ "$IPERF_VERSION" == "1.0.7" ]]; then wget https://iperf.fr/download/source/iperf-1.7.0-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "2.0.1" ]]; then wget https://iperf.fr/download/source/iperf-2.0.1-source.tar.gz ;fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xvf iperf-*-source.tar.gz ;fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd iperf-*-source ;fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./bootstrap.sh ;fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure && make && make install ;fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd .. ;fi
+      #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq ;fi
+      #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y iperf3 ;fi
     # Install iperf3, python3 and activate venv for osx
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/esnet/iperf.git ;fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd iperf ;fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+os: linux
+sudo: required
+dist: trusty
 python:
     - "2.6"
     - "2.7"
@@ -7,29 +10,23 @@ python:
     - "3.5"
     - "3.5-dev"
     - "nightly"
-matrix:
-    include:
-        # Use the built in venv for linux builds
-        - os: linux
-          sudo: required
-          dist: trusty
-          env:
-              - IPERF_VERSION="3.0.1"
-              - IPERF_VERSION="3.0.2"
-              - IPERF_VERSION="3.0.3"
-              - IPERF_VERSION="3.0.4"
-              - IPERF_VERSION="3.0.5"
-              - IPERF_VERSION="3.0.6"
-              - IPERF_VERSION="3.0.7"
-              - IPERF_VERSION="3.0.8"
-              - IPERF_VERSION="3.0.9"
-              - IPERF_VERSION="3.0.10"
-              - IPERF_VERSION="3.0.11"
-              - IPERF_VERSION="3.0.12"
-              - IPERF_VERSION="3.1"
-              - IPERF_VERSION="3.1.1"
-              - IPERF_VERSION="3.1.2"
-              - IPERF_VERSION="3.1.3"
+env:
+  - IPERF_VERSION="3.0.1"
+  - IPERF_VERSION="3.0.2"
+  - IPERF_VERSION="3.0.3"
+  - IPERF_VERSION="3.0.4"
+  - IPERF_VERSION="3.0.5"
+  - IPERF_VERSION="3.0.6"
+  - IPERF_VERSION="3.0.7"
+  - IPERF_VERSION="3.0.8"
+  - IPERF_VERSION="3.0.9"
+  - IPERF_VERSION="3.0.10"
+  - IPERF_VERSION="3.0.11"
+  - IPERF_VERSION="3.0.12"
+  - IPERF_VERSION="3.1"
+  - IPERF_VERSION="3.1.1"
+  - IPERF_VERSION="3.1.2"
+  - IPERF_VERSION="3.1.3"
 before_install:
     # Download the various available iperf3 sources
     - if [[ "$IPERF_VERSION" == "3.0.1" ]]; then wget https://iperf.fr/download/source/iperf-3.0.1-source.tar.gz ;fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,40 +5,52 @@ matrix:
         - os: linux
           sudo: required
           dist: trusty
-          python: "2.6"
-        - os: linux
-          sudo: required
-          dist: trusty
-          python: "2.7"
-        - os: linux
-          sudo: required
-          dist: trusty
-          python: "3.3"
-        - os: linux
-          sudo: required
-          dist: trusty
-          python: "3.4"
-        - os: linux
-          sudo: required
-          dist: trusty
-          python: "3.5"
-        - os: linux
-          sudo: required
-          dist: trusty
-          python: "3.5-dev"
-        - os: linux
-          sudo: required
-          dist: trusty
-          python: "nightly"
+          python: 
+            - "2.6"
+            - "2.7"
+            - "3.3"
+            - "3.4"
+            - "3.5"
+            - "3.5-dev"
+            - "nightly"
           env:
-              - IPERF_VERSION="1.0.7"
-              - IPERF_VERSION="2.0.1"
+              - IPERF_VERSION="3.0.1"
+              - IPERF_VERSION="3.0.2"
+              - IPERF_VERSION="3.0.3"
+              - IPERF_VERSION="3.0.4"
+              - IPERF_VERSION="3.0.5"
+              - IPERF_VERSION="3.0.6"
+              - IPERF_VERSION="3.0.7"
+              - IPERF_VERSION="3.0.8"
+              - IPERF_VERSION="3.0.9"
+              - IPERF_VERSION="3.0.10"
+              - IPERF_VERSION="3.0.11"
+              - IPERF_VERSION="3.0.12"
+              - IPERF_VERSION="3.1"
+              - IPERF_VERSION="3.1.1"
+              - IPERF_VERSION="3.1.2"
+              - IPERF_VERSION="3.1.3"
 before_install:
-    # Install iperf3 on linux
-    - if [[ "$IPERF_VERSION" == "1.0.7" ]]; then wget https://iperf.fr/download/source/iperf-1.7.0-source.tar.gz ;fi
-    - if [[ "$IPERF_VERSION" == "2.0.1" ]]; then wget https://iperf.fr/download/source/iperf-2.0.1-source.tar.gz ;fi
+    # Download the various available iperf3 sources
+    - if [[ "$IPERF_VERSION" == "3.0.1" ]]; then wget https://iperf.fr/download/source/iperf-3.0.1-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.0.2" ]]; then wget https://iperf.fr/download/source/iperf-3.0.2-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.0.3" ]]; then wget https://iperf.fr/download/source/iperf-3.0.3-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.0.4" ]]; then wget https://iperf.fr/download/source/iperf-3.0.4-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.0.5" ]]; then wget https://iperf.fr/download/source/iperf-3.0.5-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.0.6" ]]; then wget https://iperf.fr/download/source/iperf-3.0.6-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.0.7" ]]; then wget https://iperf.fr/download/source/iperf-3.0.7-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.0.8" ]]; then wget https://iperf.fr/download/source/iperf-3.0.8-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.0.9" ]]; then wget https://iperf.fr/download/source/iperf-3.0.9-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.0.10" ]]; then wget https://iperf.fr/download/source/iperf-3.0.10-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.0.11" ]]; then wget https://iperf.fr/download/source/iperf-3.0.11-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.0.12" ]]; then wget https://iperf.fr/download/source/iperf-3.0.12-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.1" ]]; then wget https://iperf.fr/download/source/iperf-3.1-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.1.1" ]]; then wget https://iperf.fr/download/source/iperf-3.1.1-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.1.2" ]]; then wget https://iperf.fr/download/source/iperf-3.1.2-source.tar.gz ;fi
+    - if [[ "$IPERF_VERSION" == "3.1.3" ]]; then wget https://iperf.fr/download/source/iperf-3.1.3-source.tar.gz ;fi
+    # Install iperf version selected above
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xvf iperf-*-source.tar.gz ;fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd iperf-*-source ;fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd iperf-*/ ;fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./bootstrap.sh ;fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure && make && make install ;fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd .. ;fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,6 @@ python:
     - "3.5-dev"
     - "nightly"
 env:
-  - IPERF_VERSION="3.0.1"
-  - IPERF_VERSION="3.0.2"
-  - IPERF_VERSION="3.0.3"
-  - IPERF_VERSION="3.0.4"
-  - IPERF_VERSION="3.0.5"
   - IPERF_VERSION="3.0.6"
   - IPERF_VERSION="3.0.7"
   - IPERF_VERSION="3.0.8"
@@ -29,11 +24,6 @@ env:
   - IPERF_VERSION="3.1.3"
 before_install:
     # Download the various available iperf3 sources
-    - if [[ "$IPERF_VERSION" == "3.0.1" ]]; then wget https://iperf.fr/download/source/iperf-3.0.1-source.tar.gz ;fi
-    - if [[ "$IPERF_VERSION" == "3.0.2" ]]; then wget https://iperf.fr/download/source/iperf-3.0.2-source.tar.gz ;fi
-    - if [[ "$IPERF_VERSION" == "3.0.3" ]]; then wget https://iperf.fr/download/source/iperf-3.0.3-source.tar.gz ;fi
-    - if [[ "$IPERF_VERSION" == "3.0.4" ]]; then wget https://iperf.fr/download/source/iperf-3.0.4-source.tar.gz ;fi
-    - if [[ "$IPERF_VERSION" == "3.0.5" ]]; then wget https://iperf.fr/download/source/iperf-3.0.5-source.tar.gz ;fi
     - if [[ "$IPERF_VERSION" == "3.0.6" ]]; then wget https://iperf.fr/download/source/iperf-3.0.6-source.tar.gz ;fi
     - if [[ "$IPERF_VERSION" == "3.0.7" ]]; then wget https://iperf.fr/download/source/iperf-3.0.7-source.tar.gz ;fi
     - if [[ "$IPERF_VERSION" == "3.0.8" ]]; then wget https://iperf.fr/download/source/iperf-3.0.8-source.tar.gz ;fi
@@ -52,18 +42,6 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure && make && sudo make install ;fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd .. ;fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export LD_LIBRARY_PATH=/usr/local/lib ;fi
-      #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq ;fi
-      #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y iperf3 ;fi
-    # Install iperf3, python3 and activate venv for osx
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/esnet/iperf.git ;fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd iperf ;fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./bootstrap.sh ;fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./configure && make && make install ;fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd .. ;fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ;fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3 ;fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then virtualenv venv -p python3 ;fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source venv/bin/activate ;fi
 install: 
     - "pip install -r requirements.txt"
     - "pip install coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xvf iperf-*-source.tar.gz ;fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd iperf-*/ ;fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./bootstrap.sh ;fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure && make && make install ;fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure && make && sudo make install ;fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd .. ;fi
       #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq ;fi
       #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y iperf3 ;fi

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ---------------
 
+0.1.1 (2016-09-12)
+++++++++++++++++++
+
+- Added reverse test parameter (thanks to @cvicente)
+- Updated travis build to test against iperf3 versions 3.0.6 through 3.1.3
+
 0.1.0 (2016-08-18)
 ++++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ of iperf3 installation.
     wget http://downloads.es.net/pub/iperf/iperf-3-current.tar.gz
     tar xvf iperf-3-current.tar.gz
     cd iperf-3.1.3/                # Or whatever the latest version is
-    ./configure && make && make install
+    ./configure && make && sudo make install
 
 - Ubuntu 16.04 LTS:
 
@@ -106,26 +106,26 @@ Testing
 -------
 
 - Tested against the following iperf3 versions on Unix (ubuntu Trusty).
-    * 3.0.6
-    * 3.0.7
-    * 3.0.8
-    * 3.0.9
-    * 3.0.10
-    * 3.0.11
-    * 3.0.12
-    * 3.1
-    * 3.1.1
-    * 3.1.2
-    * 3.1.3
+  - 3.0.6
+  - 3.0.7
+  - 3.0.8
+  - 3.0.9
+  - 3.0.10
+  - 3.0.11
+  - 3.0.12
+  - 3.1
+  - 3.1.1
+  - 3.1.2
+  - 3.1.3
 - Test coverage reporting through `coveralls.io <https://coveralls.io/>`__
 - Tested against the following Python versions:
-    * 2.6
-    * 2.7
-    * 3.3
-    * 3.4
-    * 3.5
-    * 3.5-dev 
-    * nightly
+  - 2.6
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.5-dev 
+  - nightly
 
 .. |PyPi Status| image:: https://img.shields.io/pypi/v/iperf3.svg
    :target: https://pypi.python.org/pypi/iperf3

--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ External Dependencies
 Testing
 -------
 
-- Tested against the following iperf3 versions on Unix (ubuntu Trusty).
+- Tested against the following iperf3 versions on Unix (ubuntu Trusty):
   - 3.0.6
   - 3.0.7
   - 3.0.8

--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,8 @@ The common linux distributions offer installations from their own repositories. 
 might be out of date so installation from the official `iperf3 website <http://software.es.net/iperf/>`__
 is preferred. 
 
-**warning** there seems to be an issue with iperf3 v3.0.7 causing a memory dump. To resolve this make sure
-to use the latest iperf3 version.
+**note** The libiperf API was only introduced in 3.0.6 so make sure you have an updated version
+of iperf3 installation.
 
 - Install from source (preferred)
 
@@ -100,12 +100,23 @@ External Dependencies
 ---------------------
 
 -  iperf3
--  libiperf.0 (should come with iperf3
+-  libiperf.so.0 (Comes with iperf3 >= 3.0.6)
 
 Testing
 -------
 
-- Tested against Ubuntu 14.04 LTS standard iperf3 installation using `travis-ci <https://travis-ci.org/>`__
+- Tested against the following iperf3 versions on Unix (ubuntu Trusty).
+    * 3.0.6
+    * 3.0.7
+    * 3.0.8
+    * 3.0.9
+    * 3.0.10
+    * 3.0.11
+    * 3.0.12
+    * 3.1
+    * 3.1.1
+    * 3.1.2
+    * 3.1.3
 - Test coverage reporting through `coveralls.io <https://coveralls.io/>`__
 - Tested against the following Python versions:
     * 2.6

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,7 +66,7 @@ author = 'Mathijs Mortimer'
 # built documents.
 #
 # The short X.Y version.
-version = '0.1.0'
+version = '0.1.1'
 # The full version, including alpha/beta/rc tags.
 release = '0.1.0'
 

--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -30,11 +30,15 @@ try:
 except ImportError:
     from Queue import Queue  # Python2 compatibility
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 
 def more_data(pipe_out):
-    """Check if there is more data left on the pipe"""
+    """Check if there is more data left on the pipe
+    
+    :param pipe_out: The os pipe_out
+    :rtype: bool
+    """
     r, _, _ = select.select([pipe_out], [], [], 0)
     return bool(r)
 
@@ -42,7 +46,11 @@ def more_data(pipe_out):
 def read_pipe(pipe_out):
     """Read data on a pipe
 
-    Used to capture stdout data produced by libiperf"""
+    Used to capture stdout data produced by libiperf
+    
+    :param pipe_out: The os pipe_out
+    :rtype: unicode string
+    """
     out = b''
     while more_data(pipe_out):
         out += os.read(pipe_out, 1024)
@@ -88,10 +96,7 @@ class IPerf3(object):
         try:
             self.lib = cdll.LoadLibrary(lib_name)
         except OSError:
-            try:
-                self.lib = cdll.LoadLibrary('libiperf.so.0.dylib')
-            except OSError:
-                raise OSError('Could not find shared library {0}. Is iperf3 installed?'.format(lib_name))
+            raise OSError('Could not find shared library {0}. Is iperf3 installed?'.format(lib_name))
 
         # The test C struct iperf_test
         self._test = self._new()
@@ -135,6 +140,8 @@ class IPerf3(object):
         """The iperf3 instance role
 
         valid roles are 'c'=client and 's'=server
+
+        :rtype: 'c' or 's'
         """
         try:
             self._role = c_char(self.lib.iperf_get_test_role(self._test)).value.decode('utf-8')
@@ -156,6 +163,7 @@ class IPerf3(object):
         """The bind address the iperf3 instance will listen on
 
         use * to listen on all available IPs
+        :rtype: string
         """
         result = c_char_p(self.lib.iperf_get_test_bind_address(self._test)).value
         if result:
@@ -234,7 +242,10 @@ class IPerf3(object):
 
     @property
     def _errno(self):
-        """Returns the last error ID"""
+        """Returns the last error ID
+        
+        :rtype: int
+        """
         return c_int.in_dll(self.lib, "i_errno").value
 
     @property
@@ -251,6 +262,7 @@ class IPerf3(object):
         """Returns an error string from libiperf
 
         :param error_id: The error_id produced by libiperf
+        :rtype: string
         """
         strerror = self.lib.iperf_strerror
         strerror.restype = c_char_p
@@ -300,6 +312,7 @@ class Client(IPerf3):
         """The server hostname to connect to.
 
         Accepts DNS entries or IP addresses
+        :rtype: string
         """
         result = c_char_p(self.lib.iperf_get_test_server_hostname(self._test)).value
         if result:
@@ -356,6 +369,8 @@ class Client(IPerf3):
 
         .. todo:: This is not working as expected, perhaps need
                   to ensure the return is indeed 1
+
+        :rtype: bool
         """
         # if self.lib.iperf_has_zerocopy() == 1:
         #     self._zerocopy = True
@@ -458,7 +473,55 @@ class Server(IPerf3):
 
 
 class TestResult(object):
-    """Class containing iperf3 test results"""
+    """Class containing iperf3 test results
+    
+    Available fields will be:
+            time        - Start time 
+            timesecs    - Start time in seconds
+
+            # generic info
+            system_info - System info
+            version     - Iperf Version
+
+            # connection details
+            local_host  - Local host ip
+            local_port  - Local port number
+            remote_host - Remote host ip
+            remote_port - Remote port number
+
+            # test setup
+            reverse
+            tcp_mss_default
+            protocol
+            num_streams
+            bulksize
+            omit
+            duration
+
+            # test results
+            sent_bytes
+            sent_bps
+            sent_kbps
+            sent_Mbps
+            sent_kB_s
+            sent_MB_s
+
+            received_bytes
+            received_bps
+            received_kbps
+            received_Mbps
+            received_kB_s
+            received_MB_s
+
+            retransmits  # Only returned from client
+
+            local_cpu_total
+            local_cpu_user
+            local_cpu_system
+            remote_cpu_total
+            remote_cpu_user
+            remote_cpu_system
+    """
 
     def __init__(self, result):
         """Initialise TestResult

--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -252,7 +252,7 @@ class IPerf3(object):
     def iperf_version(self):
         """Returns the version of the libiperf library
 
-        rtype: string
+        :rtype: string
         """
         # TODO: Is there a better way to get the const char than allocating 30?
         VersionType = c_char * 30


### PR DESCRIPTION
Updated .travis.yml to include building iperf3 versions 3.0.6 through to 3.1.3 to ensure it works on all versions.