### PR TITLE
Fixing incorrect return of reverse flag

### DIFF
--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -35,7 +35,7 @@ __version__ = '0.1.1'
 
 def more_data(pipe_out):
     """Check if there is more data left on the pipe
-    
+
     :param pipe_out: The os pipe_out
     :rtype: bool
     """
@@ -47,7 +47,7 @@ def read_pipe(pipe_out):
     """Read data on a pipe
 
     Used to capture stdout data produced by libiperf
-    
+
     :param pipe_out: The os pipe_out
     :rtype: unicode string
     """
@@ -243,7 +243,7 @@ class IPerf3(object):
     @property
     def _errno(self):
         """Returns the last error ID
-        
+
         :rtype: int
         """
         return c_int.in_dll(self.lib, "i_errno").value
@@ -499,9 +499,9 @@ class Server(IPerf3):
 
 class TestResult(object):
     """Class containing iperf3 test results
-    
+
     Available fields will be:
-            time        - Start time 
+            time        - Start time
             timesecs    - Start time in seconds
 
             # generic info
@@ -613,9 +613,9 @@ class TestResult(object):
     @property
     def reverse(self):
         if self.json['start']['test_start']['reverse']:
-            return False
-        else:
             return True
+        else:
+            return False
 
     @property
     def type(self):

--- a/tests/test_iperf3.py
+++ b/tests/test_iperf3.py
@@ -151,7 +151,7 @@ class TestPyPerf:
         assert response.remote_port == 5201
 
         # These are added to check some of the TestResult variables
-        assert response.reverse
+        assert not response.reverse
         assert response.type == 'client'
         assert response.__repr__()
 


### PR DESCRIPTION
Hi,
first, thank you very much for the work you have been doing with this project, it is really useful.
I was modifying the TestResult class to correctly handle the case in which the user wants to disable the json_output when I found out this: 
https://github.com/thiezn/iperf3-python/blob/master/iperf3/iperf3.py#L615

Here we are returning the opposite value of the reverse field respect to the JSON passed from the client. 
The semantic usage of the -R flag in iperf3 cli is (from man):

```       
-R, --reverse
              run in reverse mode (server sends, client receives)
```

which means that _reverse_ is not a relative value (i.e. it does not depends on the result being returned by the client or the server) and its default value should be False.
BTW, also the test is checking for a True value when we are actually not setting the reverse flag, line: https://github.com/thiezn/iperf3-python/blob/master/tests/test_iperf3.py#L154 . 
Checking the response from the client actually shows: 
```
[...]
"test_start":	{
			"protocol":	"TCP",
			"num_streams":	1,
			"blksize":	131072,
			"omit":	0,
			"duration":	3,
			"bytes":	0,
			"blocks":	0,
			"reverse":	0
		}
[...]
```

Thanks for any feedback provided,
Francesco

PS. my editor automatically removed some whitespaces, just noticed.