### PR TITLE
Hotfix/disable json output

### DIFF
--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -35,7 +35,7 @@ __version__ = '0.1.1'
 
 def more_data(pipe_out):
     """Check if there is more data left on the pipe
-    
+
     :param pipe_out: The os pipe_out
     :rtype: bool
     """
@@ -47,7 +47,7 @@ def read_pipe(pipe_out):
     """Read data on a pipe
 
     Used to capture stdout data produced by libiperf
-    
+
     :param pipe_out: The os pipe_out
     :rtype: unicode string
     """
@@ -243,7 +243,7 @@ class IPerf3(object):
     @property
     def _errno(self):
         """Returns the last error ID
-        
+
         :rtype: int
         """
         return c_int.in_dll(self.lib, "i_errno").value
@@ -499,9 +499,9 @@ class Server(IPerf3):
 
 class TestResult(object):
     """Class containing iperf3 test results
-    
+
     Available fields will be:
-            time        - Start time 
+            time        - Start time
             timesecs    - Start time in seconds
 
             # generic info
@@ -613,9 +613,9 @@ class TestResult(object):
     @property
     def reverse(self):
         if self.json['start']['test_start']['reverse']:
-            return False
-        else:
             return True
+        else:
+            return False
 
     @property
     def type(self):

--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -430,7 +430,7 @@ class Client(IPerf3):
 
         output_to_screen(self._stdout_fd, self._stderr_fd)
 
-        return TestResult(data)
+        return TestResult(data, self.role, self.reverse)
 
 
 class Server(IPerf3):
@@ -494,7 +494,7 @@ class Server(IPerf3):
         while t.is_alive():
             t.join(.1)
 
-        return TestResult(data_queue.get())
+        return TestResult(data_queue.get(), self.role)
 
 
 class TestResult(object):
@@ -548,7 +548,7 @@ class TestResult(object):
             remote_cpu_system
     """
 
-    def __init__(self, result):
+    def __init__(self, result, role, reverse=False):
         """Initialise TestResult
 
         :param result: raw json output from :class:`Client` and :class:`Server`
@@ -556,70 +556,80 @@ class TestResult(object):
 
         # The full result data
         self.text = result
-        self.json = json.loads(result)
+        self._is_client = True if role == 'c' else False
+        self._is_reverse = reverse
 
-        if 'error' in self.json:
-            self.error = self.json['error']
-        else:
-            self.error = None
+        try:
+            self.json = json.loads(result)
+            self._is_json = True
 
-            # start time
-            self.time = self.json['start']['timestamp']['time']
-            self.timesecs = self.json['start']['timestamp']['timesecs']
+            if 'error' in self.json:
+                self.error = self.json['error']
+            else:
+                self.error = None
 
-            # generic info
-            self.system_info = self.json['start']['system_info']
-            self.version = self.json['start']['version']
+                # start time
+                self.time = self.json['start']['timestamp']['time']
+                self.timesecs = self.json['start']['timestamp']['timesecs']
 
-            # connection details
-            self.local_host = self.json['start']['connected'][0]['local_host']
-            self.local_port = self.json['start']['connected'][0]['local_port']
-            self.remote_host = self.json['start']['connected'][0]['remote_host']
-            self.remote_port = self.json['start']['connected'][0]['remote_port']
+                # generic info
+                self.system_info = self.json['start']['system_info']
+                self.version = self.json['start']['version']
 
-            # test setup
-            self.tcp_mss_default = self.json['start']['tcp_mss_default']
-            self.protocol = self.json['start']['test_start']['protocol']
-            self.num_streams = self.json['start']['test_start']['num_streams']
-            self.bulksize = self.json['start']['test_start']['blksize']
-            self.omit = self.json['start']['test_start']['omit']
-            self.duration = self.json['start']['test_start']['duration']
+                # connection details
+                self.local_host = self.json['start']['connected'][0]['local_host']
+                self.local_port = self.json['start']['connected'][0]['local_port']
+                self.remote_host = self.json['start']['connected'][0]['remote_host']
+                self.remote_port = self.json['start']['connected'][0]['remote_port']
 
-            # test results
-            self.sent_bytes = self.json['end']['sum_sent']['bytes']
-            self.sent_bps = self.json['end']['sum_sent']['bits_per_second']
-            self.sent_kbps = self.sent_bps / 1024           # Kilobits per second
-            self.sent_Mbps = self.sent_kbps / 1024          # Megabits per second
-            self.sent_kB_s = self.sent_kbps / 8             # kiloBytes per second
-            self.sent_MB_s = self.sent_Mbps / 8             # MegaBytes per second
+                # test setup
+                self.tcp_mss_default = self.json['start']['tcp_mss_default']
+                self.protocol = self.json['start']['test_start']['protocol']
+                self.num_streams = self.json['start']['test_start']['num_streams']
+                self.bulksize = self.json['start']['test_start']['blksize']
+                self.omit = self.json['start']['test_start']['omit']
+                self.duration = self.json['start']['test_start']['duration']
 
-            self.received_bytes = self.json['end']['sum_received']['bytes']
-            self.received_bps = self.json['end']['sum_received']['bits_per_second']
-            self.received_kbps = self.received_bps / 1024   # Kilobits per second
-            self.received_Mbps = self.received_kbps / 1024  # Megabits per second
-            self.received_kB_s = self.received_kbps / 8     # kiloBytes per second
-            self.received_MB_s = self.received_Mbps / 8     # MegaBytes per second
+                # test results
+                self.sent_bytes = self.json['end']['sum_sent']['bytes']
+                self.sent_bps = self.json['end']['sum_sent']['bits_per_second']
+                self.sent_kbps = self.sent_bps / 1024           # Kilobits per second
+                self.sent_Mbps = self.sent_kbps / 1024          # Megabits per second
+                self.sent_kB_s = self.sent_kbps / 8             # kiloBytes per second
+                self.sent_MB_s = self.sent_Mbps / 8             # MegaBytes per second
 
-            # retransmits only returned from client
-            self.retransmits = self.json['end']['sum_sent'].get('retransmits', None)
+                self.received_bytes = self.json['end']['sum_received']['bytes']
+                self.received_bps = self.json['end']['sum_received']['bits_per_second']
+                self.received_kbps = self.received_bps / 1024   # Kilobits per second
+                self.received_Mbps = self.received_kbps / 1024  # Megabits per second
+                self.received_kB_s = self.received_kbps / 8     # kiloBytes per second
+                self.received_MB_s = self.received_Mbps / 8     # MegaBytes per second
 
-            self.local_cpu_total = self.json['end']['cpu_utilization_percent']['host_total']
-            self.local_cpu_user = self.json['end']['cpu_utilization_percent']['host_user']
-            self.local_cpu_system = self.json['end']['cpu_utilization_percent']['host_system']
-            self.remote_cpu_total = self.json['end']['cpu_utilization_percent']['remote_total']
-            self.remote_cpu_user = self.json['end']['cpu_utilization_percent']['remote_user']
-            self.remote_cpu_system = self.json['end']['cpu_utilization_percent']['remote_system']
+                # retransmits only returned from client
+                self.retransmits = self.json['end']['sum_sent'].get('retransmits', None)
+
+                self.local_cpu_total = self.json['end']['cpu_utilization_percent']['host_total']
+                self.local_cpu_user = self.json['end']['cpu_utilization_percent']['host_user']
+                self.local_cpu_system = self.json['end']['cpu_utilization_percent']['host_system']
+                self.remote_cpu_total = self.json['end']['cpu_utilization_percent']['remote_total']
+                self.remote_cpu_user = self.json['end']['cpu_utilization_percent']['remote_user']
+                self.remote_cpu_system = self.json['end']['cpu_utilization_percent']['remote_system']
+
+        except ValueError:
+            self.json = {}
+            self._is_json = False
+
+    @property
+    def is_json(self):
+        return self._is_json
 
     @property
     def reverse(self):
-        if self.json['start']['test_start']['reverse']:
-            return True
-        else:
-            return False
+        return self._is_reverse
 
     @property
     def type(self):
-        if 'connecting_to' in self.json['start']:
+        if self._is_client:
             return 'client'
         else:
             return 'server'

--- a/tests/test_iperf3.py
+++ b/tests/test_iperf3.py
@@ -151,7 +151,7 @@ class TestPyPerf:
         assert response.remote_port == 5201
 
         # These are added to check some of the TestResult variables
-        assert response.reverse
+        assert not response.reverse
         assert response.type == 'client'
         assert response.__repr__()
 


### PR DESCRIPTION
This hotfix allows to enable json_output=False without generating parsing error in the TestResults class. It just redirects the output to screen. The result object will then just have the text field, while to keep the other two properties available I pass the role and optionally the reverse flag parameter to the result class.
