### PR TITLE
pipes and fds not closed on IPerf3.__del__()

### DIFF
--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -117,10 +117,23 @@ class IPerf3(object):
         self.json_output = True
         self.verbose = verbose
 
-
     def __del__(self):
         """Cleanup the test after the :class:`IPerf3` class is terminated"""
+        os.close(self._stdout_fd)
+        os.close(self._stderr_fd)
+        os.close(self._pipe_out)
+        os.close(self._pipe_in)
+
         try:
+            # In the current version of libiperf, the control socket isn't closed on iperf_client_end()
+            # See proposed solution in pull request: https://github.com/esnet/iperf/pull/597
+            #
+            # Workaround for testing, don't ever do this..:
+            #
+            # sck=self.lib.iperf_get_control_socket(self._test)
+            # os.close(sck)
+
+            self.lib.iperf_client_end(self._test)
             self.lib.iperf_free_test(self._test)
         except AttributeError:
             # self.lib doesn't exist, likely because iperf3 wasn't installed or


### PR DESCRIPTION
This should fix resource leaks on file descriptors.

This fixed the _IOError: [Errno 24] Too many open files_ I'm getting while running repeated client tests using this module.

Further, there's also a resource leak in libiperf. I've added a pull request for that, see [https://github.com/esnet/iperf/pull/597](https://github.com/esnet/iperf/pull/597).

Here's a simple test:
~~~~
#!/usr/bin/env python3

import iperf3

counter=0

def test():
    client = iperf3.Client()
    client.duration = 1
    client.server_hostname = '127.0.0.1'
    client.port = 5201
    result = client.run()

    if result.error:
        print(result.error)
    else:
        print('{0} Test completed (MB/s: {1})'.format(counter, result.sent_MB_s))

while True:
    test()
    counter+=1
~~~~