### PR TITLE
Fix calculation in Mpbs vs MB_s

### DIFF
--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -32,7 +32,7 @@ except ImportError:
     from Queue import Queue  # Python2 compatibility
 
 
-__version__ = '0.1.6'
+__version__ = '0.1.7'
 
 
 MAX_UDP_BULKSIZE = (65535 - 8 - 20)
@@ -700,15 +700,16 @@ class TestResult(object):
                 self.received_bytes = self.json['end']['sum_received']['bytes']
                 self.received_bps = self.json['end']['sum_received']['bits_per_second']
 
-                self.sent_kbps = self.sent_bps / 1024           # Kilobits per second
-                self.sent_Mbps = self.sent_kbps / 1024          # Megabits per second
-                self.sent_kB_s = self.sent_kbps / 8             # kiloBytes per second
-                self.sent_MB_s = self.sent_Mbps / 8             # MegaBytes per second
+                #  Bits are measured in 10**3 terms, Bytes are measured in 2**10 terms
+                self.sent_kbps = self.sent_bps / 1000           # Kilobits per second
+                self.sent_Mbps = self.sent_kbps / 1000          # Megabits per second
+                self.sent_kB_s = self.sent_bps / (8 * 1024)     # kiloBytes per second
+                self.sent_MB_s = self.sent_kB_s / 1024          # MegaBytes per second
 
-                self.received_kbps = self.received_bps / 1024   # Kilobits per second
-                self.received_Mbps = self.received_kbps / 1024  # Megabits per second
-                self.received_kB_s = self.received_kbps / 8     # kiloBytes per second
-                self.received_MB_s = self.received_Mbps / 8     # MegaBytes per second
+                self.received_kbps = self.received_bps / 1000   # Kilobits per second
+                self.received_Mbps = self.received_kbps / 1000  # Megabits per second
+                self.received_kB_s = self.received_bps / (8* 1024)     # kiloBytes per second
+                self.received_MB_s = self.received_kB_s / 1024     # MegaBytes per second
 
                 # retransmits only returned from client
                 self.retransmits = self.json['end']['sum_sent'].get('retransmits', None)
@@ -718,10 +719,10 @@ class TestResult(object):
                 self.bytes = self.json['end']['sum']['bytes']
                 self.bps = self.json['end']['sum']['bits_per_second']
                 self.jitter_ms = self.json['end']['sum']['jitter_ms']
-                self.kbps = self.bps / 1024
-                self.Mbps = self.kbps / 1024
-                self.kB_s = self.kbps / 8
-                self.MB_s = self.Mbps / 8
+                self.kbps = self.bps / 1000
+                self.Mbps = self.kbps / 1000
+                self.kB_s = self.kbps / (8 * 1024)
+                self.MB_s = self.Mbps / 1024
                 self.packets = self.json['end']['sum']['packets']
                 self.lost_packets = self.json['end']['sum']['lost_packets']
                 self.lost_percent = self.json['end']['sum']['lost_percent']

--- a/tests/results.json
+++ b/tests/results.json
@@ -1,0 +1,351 @@
+{
+	"start":	{
+		"connected":	[{
+				"socket":	4,
+				"local_host":	"192.168.0.3",
+				"local_port":	60166,
+				"remote_host":	"192.168.0.188",
+				"remote_port":	9987
+			}],
+		"version":	"iperf 3.0.11",
+		"system_info":	"Linux rhowelllx 4.4.0-79-generic #100-Ubuntu SMP Wed May 17 19:58:14 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux\n",
+		"timestamp":	{
+			"time":	"Wed, 28 Jun 2017 15:31:28 GMT",
+			"timesecs":	1498663888
+		},
+		"connecting_to":	{
+			"host":	"192.168.0.188",
+			"port":	9987
+		},
+		"cookie":	"rhowelllx.1498663888.027091.78beffbd",
+		"tcp_mss_default":	1448,
+		"test_start":	{
+			"protocol":	"TCP",
+			"num_streams":	1,
+			"blksize":	131072,
+			"omit":	0,
+			"duration":	13,
+			"bytes":	0,
+			"blocks":	0,
+			"reverse":	0
+		}
+	},
+	"intervals":	[{
+			"streams":	[{
+					"socket":	4,
+					"start":	0,
+					"end":	1.00007,
+					"seconds":	1.00007,
+					"bytes":	118766408,
+					"bits_per_second":	9.50062e+08,
+					"retransmits":	0,
+					"snd_cwnd":	573408,
+					"omitted":	false
+				}],
+			"sum":	{
+				"start":	0,
+				"end":	1.00007,
+				"seconds":	1.00007,
+				"bytes":	118766408,
+				"bits_per_second":	9.50062e+08,
+				"retransmits":	0,
+				"omitted":	false
+			}
+		}, {
+			"streams":	[{
+					"socket":	4,
+					"start":	1.00007,
+					"end":	2.00006,
+					"seconds":	0.999984,
+					"bytes":	117548640,
+					"bits_per_second":	9.40404e+08,
+					"retransmits":	0,
+					"snd_cwnd":	573408,
+					"omitted":	false
+				}],
+			"sum":	{
+				"start":	1.00007,
+				"end":	2.00006,
+				"seconds":	0.999984,
+				"bytes":	117548640,
+				"bits_per_second":	9.40404e+08,
+				"retransmits":	0,
+				"omitted":	false
+			}
+		}, {
+			"streams":	[{
+					"socket":	4,
+					"start":	2.00006,
+					"end":	3.00006,
+					"seconds":	1,
+					"bytes":	116375760,
+					"bits_per_second":	9.31005e+08,
+					"retransmits":	0,
+					"snd_cwnd":	573408,
+					"omitted":	false
+				}],
+			"sum":	{
+				"start":	2.00006,
+				"end":	3.00006,
+				"seconds":	1,
+				"bytes":	116375760,
+				"bits_per_second":	9.31005e+08,
+				"retransmits":	0,
+				"omitted":	false
+			}
+		}, {
+			"streams":	[{
+					"socket":	4,
+					"start":	3.00006,
+					"end":	4.00006,
+					"seconds":	1,
+					"bytes":	116310600,
+					"bits_per_second":	930484800,
+					"retransmits":	0,
+					"snd_cwnd":	573408,
+					"omitted":	false
+				}],
+			"sum":	{
+				"start":	3.00006,
+				"end":	4.00006,
+				"seconds":	1,
+				"bytes":	116310600,
+				"bits_per_second":	930484800,
+				"retransmits":	0,
+				"omitted":	false
+			}
+		}, {
+			"streams":	[{
+					"socket":	4,
+					"start":	4.00006,
+					"end":	5.00006,
+					"seconds":	1,
+					"bytes":	117678960,
+					"bits_per_second":	941431680,
+					"retransmits":	0,
+					"snd_cwnd":	573408,
+					"omitted":	false
+				}],
+			"sum":	{
+				"start":	4.00006,
+				"end":	5.00006,
+				"seconds":	1,
+				"bytes":	117678960,
+				"bits_per_second":	941431680,
+				"retransmits":	0,
+				"omitted":	false
+			}
+		}, {
+			"streams":	[{
+					"socket":	4,
+					"start":	5.00006,
+					"end":	6.00006,
+					"seconds":	1,
+					"bytes":	116831880,
+					"bits_per_second":	934655040,
+					"retransmits":	0,
+					"snd_cwnd":	640016,
+					"omitted":	false
+				}],
+			"sum":	{
+				"start":	5.00006,
+				"end":	6.00006,
+				"seconds":	1,
+				"bytes":	116831880,
+				"bits_per_second":	934655040,
+				"retransmits":	0,
+				"omitted":	false
+			}
+		}, {
+			"streams":	[{
+					"socket":	4,
+					"start":	6.00006,
+					"end":	7.00006,
+					"seconds":	0.999999,
+					"bytes":	117353160,
+					"bits_per_second":	9.38826e+08,
+					"retransmits":	0,
+					"snd_cwnd":	640016,
+					"omitted":	false
+				}],
+			"sum":	{
+				"start":	6.00006,
+				"end":	7.00006,
+				"seconds":	0.999999,
+				"bytes":	117353160,
+				"bits_per_second":	9.38826e+08,
+				"retransmits":	0,
+				"omitted":	false
+			}
+		}, {
+			"streams":	[{
+					"socket":	4,
+					"start":	7.00006,
+					"end":	8.00006,
+					"seconds":	1,
+					"bytes":	115984800,
+					"bits_per_second":	9.27877e+08,
+					"retransmits":	0,
+					"snd_cwnd":	640016,
+					"omitted":	false
+				}],
+			"sum":	{
+				"start":	7.00006,
+				"end":	8.00006,
+				"seconds":	1,
+				"bytes":	115984800,
+				"bits_per_second":	9.27877e+08,
+				"retransmits":	0,
+				"omitted":	false
+			}
+		}, {
+			"streams":	[{
+					"socket":	4,
+					"start":	8.00006,
+					"end":	9.00007,
+					"seconds":	1.00001,
+					"bytes":	117613800,
+					"bits_per_second":	9.40903e+08,
+					"retransmits":	0,
+					"snd_cwnd":	640016,
+					"omitted":	false
+				}],
+			"sum":	{
+				"start":	8.00006,
+				"end":	9.00007,
+				"seconds":	1.00001,
+				"bytes":	117613800,
+				"bits_per_second":	9.40903e+08,
+				"retransmits":	0,
+				"omitted":	false
+			}
+		}, {
+			"streams":	[{
+					"socket":	4,
+					"start":	9.00007,
+					"end":	10.0001,
+					"seconds":	1.00001,
+					"bytes":	115984800,
+					"bits_per_second":	9.27871e+08,
+					"retransmits":	0,
+					"snd_cwnd":	640016,
+					"omitted":	false
+				}],
+			"sum":	{
+				"start":	9.00007,
+				"end":	10.0001,
+				"seconds":	1.00001,
+				"bytes":	115984800,
+				"bits_per_second":	9.27871e+08,
+				"retransmits":	0,
+				"omitted":	false
+			}
+		}, {
+			"streams":	[{
+					"socket":	4,
+					"start":	10.0001,
+					"end":	11.0001,
+					"seconds":	0.999983,
+					"bytes":	117360680,
+					"bits_per_second":	9.38902e+08,
+					"retransmits":	0,
+					"snd_cwnd":	640016,
+					"omitted":	false
+				}],
+			"sum":	{
+				"start":	10.0001,
+				"end":	11.0001,
+				"seconds":	0.999983,
+				"bytes":	117360680,
+				"bits_per_second":	9.38902e+08,
+				"retransmits":	0,
+				"omitted":	false
+			}
+		}, {
+			"streams":	[{
+					"socket":	4,
+					"start":	11.0001,
+					"end":	12.0001,
+					"seconds":	1,
+					"bytes":	116531240,
+					"bits_per_second":	9.32249e+08,
+					"retransmits":	0,
+					"snd_cwnd":	941200,
+					"omitted":	false
+				}],
+			"sum":	{
+				"start":	11.0001,
+				"end":	12.0001,
+				"seconds":	1,
+				"bytes":	116531240,
+				"bits_per_second":	9.32249e+08,
+				"retransmits":	0,
+				"omitted":	false
+			}
+		}, {
+			"streams":	[{
+					"socket":	4,
+					"start":	12.0001,
+					"end":	13.0001,
+					"seconds":	1.00001,
+					"bytes":	116654080,
+					"bits_per_second":	9.33228e+08,
+					"retransmits":	0,
+					"snd_cwnd":	941200,
+					"omitted":	false
+				}],
+			"sum":	{
+				"start":	12.0001,
+				"end":	13.0001,
+				"seconds":	1.00001,
+				"bytes":	116654080,
+				"bits_per_second":	9.33228e+08,
+				"retransmits":	0,
+				"omitted":	false
+			}
+		}],
+	"end":	{
+		"streams":	[{
+				"sender":	{
+					"socket":	4,
+					"start":	0,
+					"end":	13.0001,
+					"seconds":	13.0001,
+					"bytes":	1520994808,
+					"bits_per_second":	9.35992e+08,
+					"retransmits":	0
+				},
+				"receiver":	{
+					"socket":	4,
+					"start":	0,
+					"end":	13.0001,
+					"seconds":	13.0001,
+					"bytes":	1518193248,
+					"bits_per_second":	9.34268e+08
+				}
+			}],
+		"sum_sent":	{
+			"start":	0,
+			"end":	13.0001,
+			"seconds":	13.0001,
+			"bytes":	1520994808,
+			"bits_per_second":	9.35992e+08,
+			"retransmits":	0
+		},
+		"sum_received":	{
+			"start":	0,
+			"end":	13.0001,
+			"seconds":	13.0001,
+			"bytes":	1518193248,
+			"bits_per_second":	9.34268e+08
+		},
+		"cpu_utilization_percent":	{
+			"host_total":	1.66812,
+			"host_user":	0.0611844,
+			"host_system":	1.59079,
+			"remote_total":	4.15082,
+			"remote_user":	0.156562,
+			"remote_system":	3.99574
+		}
+	}
+}

--- a/tests/test_iperf3.py
+++ b/tests/test_iperf3.py
@@ -302,3 +302,23 @@ class TestPyPerf:
         server.kill()
 
         assert response == None
+
+    def test_result(self):
+        from math import isclose
+        with open('results.json') as f:
+            json = f.read()
+
+        result = iperf3.TestResult(json)
+        assert result.sent_bps  == 935992000
+        assert result.sent_kbps == 935992
+        assert result.sent_Mbps == 935.992
+        assert isclose(result.sent_kB_s, 114256.836, rel_tol=0.01)
+        assert isclose(result.sent_MB_s, 111.579, rel_tol=0.01)
+
+        assert result.received_bps  == 934268000
+        assert result.received_kbps  == 934268
+        assert result.received_Mbps  == 934.268
+
+        assert isclose(result.received_kB_s, 114046.387, rel_tol=0.01)
+        assert isclose(result.received_MB_s, 111.373, rel_tol=0.01)
+

--- a/tests/test_iperf3.py
+++ b/tests/test_iperf3.py
@@ -1,3 +1,4 @@
+import os
 import iperf3
 import pytest
 import subprocess
@@ -306,7 +307,8 @@ class TestPyPerf:
         assert response == None
 
     def test_result(self):
-        with open('results.json') as f:
+        dirname = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(dirname, 'results.json')) as f:
             json = f.read()
 
         result = iperf3.TestResult(json)

--- a/tests/test_iperf3.py
+++ b/tests/test_iperf3.py
@@ -3,6 +3,8 @@ import pytest
 import subprocess
 from time import sleep
 
+def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
+    return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 class TestPyPerf:
 
@@ -304,7 +306,6 @@ class TestPyPerf:
         assert response == None
 
     def test_result(self):
-        from math import isclose
         with open('results.json') as f:
             json = f.read()
 


### PR DESCRIPTION
I was getting conflicting Mbits/sec results from iperf3-python vs iperf3 on the command line. After investigation, I found the math error.

Commit msg:
When measuring in bits (kbps and Mbps), use k == 1000, M == 1000000
When measuring in bytes (kB_s and MB_s), use k == 1024, M == 1024**2

Also added a unittest for this calculation