### PR TITLE
Use find_library to load libiperf 

### DIFF
--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -88,15 +88,16 @@ class IPerf3(object):
     """
     def __init__(self,
                  role,
-                 verbose=True,
-                 lib_name='libiperf.so.0'):
+                 verbose=True):
         """Initialise the iperf shared library
 
         :param role: 'c' = client; 's' = server
         :param verbose: enable verbose output
-        :param lib_name: The libiperf name providing the API to iperf3
         """
-        # TODO use find_library to find the best library
+        lib_name = util.find_library('libiperf')
+        if lib_name is None:
+            lib_name = 'libiperf.so.0'
+
         try:
             self.lib = cdll.LoadLibrary(lib_name)
         except OSError:

--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -18,7 +18,7 @@ To get started quickly see the :ref:`examples` page.
 .. moduleauthor:: Mathijs Mortimer <mathijs@mortimer.nl>
 """
 
-from ctypes import cdll, c_char_p, c_int, c_char, c_void_p, c_uint64
+from ctypes import util, cdll, c_char_p, c_int, c_char, c_void_p, c_uint64
 import os
 import select
 import json


### PR DESCRIPTION
Fixes an issue with hardcoded `libiperf.so.0` on Mac OS X. Tested on El Capitan 10.11.6.

(see https://github.com/thiezn/iperf3-python/issues/23)