### PR TITLE
correcting kB_s and MB_s in UDP for correct calculation

### DIFF
--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -841,8 +841,8 @@ class TestResult(object):
                 self.jitter_ms = self.json['end']['sum']['jitter_ms']
                 self.kbps = self.bps / 1000
                 self.Mbps = self.kbps / 1000
-                self.kB_s = self.kbps / (8 * 1024)
-                self.MB_s = self.Mbps / 1024
+                self.kB_s = self.kbps / 8
+                self.MB_s = self.Mbps / 8
                 self.packets = self.json['end']['sum']['packets']
                 self.lost_packets = self.json['end']['sum']['lost_packets']
                 self.lost_percent = self.json['end']['sum']['lost_percent']

--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -841,8 +841,8 @@ class TestResult(object):
                 self.jitter_ms = self.json['end']['sum']['jitter_ms']
                 self.kbps = self.bps / 1000
                 self.Mbps = self.kbps / 1000
-                self.kB_s = self.kbps / 8
-                self.MB_s = self.Mbps / 8
+                self.kB_s = self.bps / (8 * 1024)
+                self.MB_s = self.kB_s / 1024
                 self.packets = self.json['end']['sum']['packets']
                 self.lost_packets = self.json['end']['sum']['lost_packets']
                 self.lost_percent = self.json['end']['sum']['lost_percent']


### PR DESCRIPTION
During using of the Python Wrapper I saw that kB_s and MB_s are not correctly calculated. This is the fix for it