### PR TITLE
Support omit option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ External Dependencies
 Testing
 -------
 
-- Tested against the following iperf3 versions on Unix (ubuntu Trusty):
+- Tested against the following iperf3 versions on Linux:
 
   - 3.0.6
   - 3.0.7
@@ -130,6 +130,7 @@ Testing
   - 3.1.7
   - 3.2
   - 3.3
+  - 3.6
 
 - Test coverage reporting through `coveralls.io <https://coveralls.io/>`__
 - Tested against the following Python versions:

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -17,6 +17,7 @@ available options for a :class:`Client <iperf3.Client>`
 >>> import iperf3
 
 >>> client = iperf3.Client()
+>>> client.omit = 1
 >>> client.duration = 1
 >>> client.bind_address = '10.0.0.1'
 >>> client.server_hostname = '10.10.10.10'

--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -152,6 +152,10 @@ class IPerf3(object):
         self.lib.iperf_get_test_protocol_id.argtypes = (c_void_p,)
         self.lib.set_protocol.restype = c_int
         self.lib.set_protocol.argtypes = (c_void_p, c_int,)
+        self.lib.iperf_get_test_omit.restype = c_int
+        self.lib.iperf_get_test_omit.argtypes = (c_void_p,)
+        self.lib.iperf_set_test_omit.restype = None
+        self.lib.iperf_set_test_omit.argtypes = (c_void_p, c_int,)
         self.lib.iperf_get_test_duration.restype = c_int
         self.lib.iperf_get_test_duration.argtypes = (c_void_p,)
         self.lib.iperf_set_test_duration.restype = None
@@ -419,6 +423,8 @@ class Client(IPerf3):
         self._port = None
         self._num_streams = None
         self._zerocopy = False
+        self._omit = None
+        self._duration = None
         self._bandwidth = None
         self._protocol = None
 
@@ -475,6 +481,17 @@ class Client(IPerf3):
                 self.blksize = MAX_UDP_BULKSIZE
 
         self._protocol = protocol
+
+    @property
+    def omit(self):
+        """The test startup duration to omit in seconds."""
+        self._omit = self.lib.iperf_get_test_omit(self._test)
+        return self._omit
+
+    @omit.setter
+    def omit(self, omit):
+        self.lib.iperf_set_test_omit(self._test, omit)
+        self._omit = omit
 
     @property
     def duration(self):
@@ -712,8 +729,8 @@ class TestResult(object):
     :param protocol: 'TCP' or 'UDP'
     :param num_streams: Number of test streams
     :param blksize:
-    :param omit:
-    :param duration: Test duration in seconds
+    :param omit: Test duration to omit in the beginning in seconds
+    :param duration: Test duration (following omit duration) in seconds
 
     :param local_cpu_total: The local total CPU load
     :param local_cpu_user: The local user CPU load

--- a/tests/test_iperf3.py
+++ b/tests/test_iperf3.py
@@ -82,6 +82,11 @@ class TestPyPerf:
         client.server_hostname = '127.0.0.1'
         assert client.server_hostname == '127.0.0.1'
 
+    def test_omit(self):
+        client = iperf3.Client()
+        client.omit = 666
+        assert client.omit == 666
+
     def test_duration(self):
         client = iperf3.Client()
         client.duration = 666


### PR DESCRIPTION
This adds the omit option. The option exists since commit esnet/iperf@5789260432e8a9fcb1bfe92e3bae99e1310c440e, which seems to be between version 3.0-BETA5 and 3.0.1. So no exception handling required.

I tried it on Ubuntu 18.04 on python 3.6 with iperf3 3.6.