### PR TITLE
Added the option of fetching the server output on the client side.

### DIFF
--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -180,6 +180,10 @@ class IPerf3(object):
         self.lib.iperf_get_test_reverse.argtypes = (c_void_p,)
         self.lib.iperf_set_test_reverse.restype = None
         self.lib.iperf_set_test_reverse.argtypes = (c_void_p, c_int,)
+        self.lib.iperf_get_test_get_server_output.restype = c_int
+        self.lib.iperf_get_test_get_server_output.argtypes = (c_void_p,)
+        self.lib.iperf_set_test_get_server_output.restype = None
+        self.lib.iperf_set_test_get_server_output.argtypes = (c_void_p, c_int,)
         self.lib.iperf_run_client.restype = c_int
         self.lib.iperf_run_client.argtypes = (c_void_p,)
         self.lib.iperf_run_server.restype = c_int
@@ -605,6 +609,21 @@ class Client(IPerf3):
             self.lib.iperf_set_test_reverse(self._test, 0)
 
         self._reverse = enabled
+    
+    @property
+    def get_server_output(self):
+        """The server output."""
+        self._server_output = self.lib.iperf_get_test_get_server_output(self._test)
+        return self._server_output
+
+    @get_server_output.setter
+    def get_server_output(self, enabled):
+        if enabled:
+            self.lib.iperf_set_test_get_server_output(self._test, 1)
+        else:
+            self.lib.iperf_set_test_get_server_output(self._test, 0)
+        
+        self._get_server_output = enabled
 
     def run(self):
         """Run the current test client.
@@ -773,6 +792,10 @@ class TestResult(object):
     :param lost_packets:
     :param lost_percent:
     :param seconds:
+
+    Server information
+
+    :param server_output: The server output (Only returned from client)
     """
 
     def __init__(self, result):
@@ -864,6 +887,10 @@ class TestResult(object):
                 self.lost_packets = self.json['end']['sum']['lost_packets']
                 self.lost_percent = self.json['end']['sum']['lost_percent']
                 self.seconds = self.json['end']['sum']['seconds']
+            
+            # Server information (Only returned from client)
+            self.server_output = self.json.get('server_output_text') or self.json.get('server_output_json')
+            
 
     @property
     def reverse(self):

--- a/tests/test_iperf3.py
+++ b/tests/test_iperf3.py
@@ -150,6 +150,16 @@ class TestPyPerf:
         client = iperf3.Client()
         client.reverse = False
         assert not client.reverse
+    
+    def test_get_server_output_enabled(self):
+        client = iperf3.Client()
+        client.get_server_output = True
+        assert client.get_server_output
+
+    def test_get_server_output__disabled(self):
+        client = iperf3.Client()
+        client.get_server_output = False
+        assert not client.get_server_output
 
     def test_get_last_error(self):
         client = iperf3.Client()
@@ -204,6 +214,66 @@ class TestPyPerf:
 
         # These are added to check some of the TestResult variables
         assert response.reverse
+        assert response.type == 'client'
+        assert response.__repr__()
+    
+    def test_client_succesful_get_server_output(self):
+        client = iperf3.Client()
+        client.server_hostname = '127.0.0.1'
+        client.port = 5203
+        client.duration = 1
+        client.get_server_output = True
+
+        server = subprocess.Popen(["iperf3", "-s", "-p", "5203"])
+        sleep(.3)  # give the server some time to start
+        response = client.run()
+        server.kill()
+
+        assert response.remote_host == '127.0.0.1'
+        assert response.remote_port == 5203
+
+        # These are added to check some of the TestResult variables
+        assert response.server_output
+        assert response.type == 'client'
+        assert response.__repr__()
+    
+    def test_client_succesful_get_server_output_json(self):
+        client = iperf3.Client()
+        client.server_hostname = '127.0.0.1'
+        client.port = 5203
+        client.duration = 1
+        client.get_server_output = True
+
+        server = subprocess.Popen(["iperf3", "-s", "-J", "-p", "5203"])
+        sleep(.3)  # give the server some time to start
+        response = client.run()
+        server.kill()
+
+        assert response.remote_host == '127.0.0.1'
+        assert response.remote_port == 5203
+
+        # These are added to check some of the TestResult variables
+        assert response.server_output
+        assert response.type == 'client'
+        assert response.__repr__()
+    
+    def test_client_unsuccesful_get_server_output(self):
+        client = iperf3.Client()
+        client.server_hostname = '127.0.0.1'
+        client.port = 5203
+        client.duration = 1
+        client.get_server_output = False
+
+        server = subprocess.Popen(["iperf3", "-s", "-p", "5203"])
+        sleep(.3)  # give the server some time to start
+        response = client.run()
+        server.kill()
+
+        assert response.remote_host == '127.0.0.1'
+        assert response.remote_port == 5203
+
+        # These are added to check some of the TestResult variables
+        assert not response.server_output
         assert response.type == 'client'
         assert response.__repr__()
 


### PR DESCRIPTION
Added the option of fetching the server output on the client side. A boolean variable (get_server_output) was added to the Client class that enables the --get-server-output argument on the original iperf3 tool when set to True. The class TestResult has also a new parameter (server_output) that is set to None when the information is not available. In addition, some tests where performed on the implemented features.