### PR TITLE
Fixed client side json_output=False feature

### DIFF
--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -632,6 +632,10 @@ class Client(IPerf3):
                 data = '{"error": "%s"}' % self._error_to_string(self._errno)
 
             return TestResult(data)
+        else:
+            self.lib.iperf_run_client(self._test)
+
+            return None
 
 
 class Server(IPerf3):


### PR DESCRIPTION
Fixed to show test results on screen, and to be able to connect to the server after run() on the client side with json_output=False