### PR TITLE
Added congestion control support

### DIFF
--- a/examples/client.py
+++ b/examples/client.py
@@ -7,9 +7,11 @@ client.duration = 1
 client.server_hostname = '127.0.0.1'
 client.port = 5201
 client.congestion_control = "bbr"
+client.extra_data = "test data"
 
 print('Connecting to {0}:{1}'.format(client.server_hostname, client.port))
 result = client.run()
+print(result)
 
 if result.error:
     print(result.error)

--- a/examples/client.py
+++ b/examples/client.py
@@ -6,6 +6,7 @@ client = iperf3.Client()
 client.duration = 1
 client.server_hostname = '127.0.0.1'
 client.port = 5201
+client.congestion_control = "bbr"
 
 print('Connecting to {0}:{1}'.format(client.server_hostname, client.port))
 result = client.run()

--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -190,6 +190,10 @@ class IPerf3(object):
         self.lib.iperf_get_test_congestion_control.argtypes = (c_void_p,)
         self.lib.iperf_set_test_congestion_control.restype = None
         self.lib.iperf_set_test_congestion_control.argtypes = (c_void_p, c_char_p)
+        self.lib.iperf_get_test_extra_data.restype = c_char_p
+        self.lib.iperf_get_test_extra_data.argtypes = (c_void_p,)
+        self.lib.iperf_set_test_extra_data.restype = None
+        self.lib.iperf_set_test_extra_data.argtypes = (c_void_p, c_char_p)
 
         try:
             # Only available from iperf v3.1 and onwards
@@ -616,6 +620,7 @@ class Client(IPerf3):
 
         :rtype: String
         """
+        self._congestion_control = self.lib.iperf_get_test_congestion_control(self._test)
         return self._congestion_control
 
     @congestion_control.setter
@@ -625,6 +630,23 @@ class Client(IPerf3):
             c_char_p(cc.encode('utf-8'))
         )
         self._congestion_control = cc
+
+    @property
+    def extra_data(self):
+        """Enables extra-data String field to be included in json output
+
+        :rtype: String
+        """
+        self._extra_data = self.lib.iperf_get_test_extra_data(self._test)
+        return self._extra_data
+
+    @extra_data.setter
+    def extra_data(self, dat: str):
+        self.lib.iperf_set_test_extra_data(
+            self._test,
+            c_char_p(dat.encode('utf-8'))
+        )
+        self._extra_data = dat
 
     def run(self):
         """Run the current test client.

--- a/iperf3/iperf3.py
+++ b/iperf3/iperf3.py
@@ -186,6 +186,10 @@ class IPerf3(object):
         self.lib.iperf_run_server.argtypes = (c_void_p,)
         self.lib.iperf_reset_test.restype = None
         self.lib.iperf_reset_test.argtypes = (c_void_p,)
+        self.lib.iperf_get_test_congestion_control.restype = c_char_p
+        self.lib.iperf_get_test_congestion_control.argtypes = (c_void_p,)
+        self.lib.iperf_set_test_congestion_control.restype = None
+        self.lib.iperf_set_test_congestion_control.argtypes = (c_void_p, c_char_p)
 
         try:
             # Only available from iperf v3.1 and onwards
@@ -605,6 +609,22 @@ class Client(IPerf3):
             self.lib.iperf_set_test_reverse(self._test, 0)
 
         self._reverse = enabled
+
+    @property
+    def congestion_control(self):
+        """Enables different TCP congestion control algorithms
+
+        :rtype: String
+        """
+        return self._congestion_control
+
+    @congestion_control.setter
+    def congestion_control(self, cc: str):
+        self.lib.iperf_set_test_congestion_control(
+            self._test,
+            c_char_p(cc.encode('utf-8'))
+        )
+        self._congestion_control = cc
 
     def run(self):
         """Run the current test client.


### PR DESCRIPTION
Added support for iperf_get_test_congestion_control and iperf_set_test_congestion_control calls, based primarily off of https://github.com/puchol/iperf3-python support for bidirectional tests.